### PR TITLE
chore: Update README.md - link CoC

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you find any bug that may be a security problem, please follow our instructio
 
 ## Code of Conduct
 
-We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone. By participating in this project, you agree to abide by its [Code of Conduct](https://github.com/SAP/.github/blob/main/CODE_OF_CONDUCT.md) at all times.
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone. By participating in this project, you agree to abide by its [Code of Conduct](https://github.com/cap-java/.github/blob/main/CODE_OF_CONDUCT.md) at all times.
 
 ## Licensing
 


### PR DESCRIPTION
Updated link to Code of Conduct. It was pointing to the CoC of the SAP org, instead of cap-java.

As a general rule, the README should link to the CoC on own org, as it is the one that is used by GitHub as a community health file.