### PR TITLE
feat: final ups schema

### DIFF
--- a/cds-feature-advanced-event-mesh/src/main/java/com/sap/cds/feature/messaging/aem/client/binding/AemEndpointView.java
+++ b/cds-feature-advanced-event-mesh/src/main/java/com/sap/cds/feature/messaging/aem/client/binding/AemEndpointView.java
@@ -16,6 +16,7 @@ import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
  */
 public class AemEndpointView {
 	private static final String ENDPOINTS_KEY = "endpoints";
+	private static final String AMQP_URI_KEY = "amqp_uri";
 	private static final String URI_KEY = "uri";
 
 	private final ServiceBinding binding;
@@ -31,7 +32,7 @@ public class AemEndpointView {
 	 *         {@link Optional}
 	 */
 	public Optional<String> getUri() {
-		return Optional.ofNullable((String) getAemEndpoint().get(URI_KEY)).map(u -> u + ":943/SEMP/v2/config");
+		return Optional.ofNullable((String) getAemEndpoint().get(URI_KEY)).map(uri -> uri + "/SEMP/v2/config");
 	}
 
 	/**
@@ -41,7 +42,7 @@ public class AemEndpointView {
 	 *         empty {@link Optional}.
 	 */
 	public Optional<String> getAmqpUri() {
-		return Optional.ofNullable((String) getAemEndpoint().get(URI_KEY)).map(u -> u.replace("https://", "amqps://") + ":5671");
+		return Optional.ofNullable((String) getAemEndpoint().get(AMQP_URI_KEY));
 	}
 
 	/**

--- a/cds-feature-advanced-event-mesh/src/test/java/com/sap/cds/feature/messaging/aem/client/binding/AemEndpointViewTest.java
+++ b/cds-feature-advanced-event-mesh/src/test/java/com/sap/cds/feature/messaging/aem/client/binding/AemEndpointViewTest.java
@@ -32,14 +32,14 @@ public class AemEndpointViewTest {
     void testGetUri() {
         Map<String, Object> credentials = Map.of(
             "endpoints", Map.of(
-                "advanced-event-mesh", Map.of("uri", "https://example.com")
+                "advanced-event-mesh", Map.of("uri", "https://example.com:123")
             )
         );
         when(serviceBinding.getCredentials()).thenReturn(credentials);
 
         Optional<String> uri = endpointView.getUri();
         assertTrue(uri.isPresent());
-        assertEquals("https://example.com:943/SEMP/v2/config", uri.get());
+        assertEquals("https://example.com:123/SEMP/v2/config", uri.get());
     }
 
     @Test
@@ -54,14 +54,14 @@ public class AemEndpointViewTest {
     void testGetAmqpUri() {
         Map<String, Object> credentials = Map.of(
             "endpoints", Map.of(
-                "advanced-event-mesh", Map.of("uri", "https://example.com")
+                "advanced-event-mesh", Map.of("amqp_uri", "amqps://example.com:456")
             )
         );
         when(serviceBinding.getCredentials()).thenReturn(credentials);
 
         Optional<String> amqpUri = endpointView.getAmqpUri();
         assertTrue(amqpUri.isPresent());
-        assertEquals("amqps://example.com:5671", amqpUri.get());
+        assertEquals("amqps://example.com:456", amqpUri.get());
     }
 
     @Test

--- a/cds-feature-advanced-event-mesh/src/test/resources/default-env.json
+++ b/cds-feature-advanced-event-mesh/src/test/resources/default-env.json
@@ -46,7 +46,8 @@
           },
           "endpoints": {
             "advanced-event-mesh": {
-              "uri": "https://broker.host.com"
+              "uri": "https://broker.host.com:123",
+              "amqp_uri": "amqps://broker.host.com:456"
             }
           }
         },


### PR DESCRIPTION
UPDATED and FINAL:
```jsonc
{
  "authentication-service": {
    "tokenendpoint": "https://<ias host>/oauth2/token",
    "clientid": "<client id>",
    "clientsecret": "<client secret>"
  },
  "endpoints": {
    "advanced-event-mesh": {
      "uri": "https://<broker host>:<port>",
      "amqp_uri": "amqps://<broker host>:<port>"
    }
  },
  "vpn": "<vpn>"
}
```