### PR TITLE
ci: skip Black Duck scan on Dependabot PRs

### DIFF
--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   blackduck:
     name: Blackduck Scan
+    if: github.actor != 'dependabot[bot]'
     environment: Codescans
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
## Summary
- Dependabot-triggered workflows do not receive Actions/environment secrets — only Dependabot secrets — so `secrets.BLACK_DUCK_TOKEN` resolves to an empty string and the scan errors with `[blackduck_token] - required parameters for blackduck is missing` (see failing run https://github.com/cap-java/cds-feature-advanced-event-mesh/actions/runs/27352257768/job/80982487913).
- Skip the `Blackduck Scan` job on Dependabot PRs via `if: github.actor != 'dependabot[bot]'`. Coverage is preserved by the existing `main`-branch Black Duck scans in `main-build.yml` and `main-build-and-deploy-oss.yml`.

## Test plan
- [ ] Merge to `main`.
- [ ] Comment `@dependabot rebase` on PR #208 to retrigger Pull Request Voter as `dependabot[bot]`.
- [ ] Confirm `Blackduck Scan` reports **skipped** and the rest of Pull Request Voter passes.
- [ ] Confirm a non-Dependabot PR still runs `Blackduck Scan` normally.

> Note: if `Blackduck Scan` is a required status check, branch protection may need to mark a skipped job as a passing state — watch for that on the first Dependabot rebase.