### PR TITLE
security: enforce AMQPS + fail fast on multiple AEM validation bindings

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -17,14 +17,14 @@ runs:
   using: composite
   steps:
     - name: Set up Java ${{ inputs.java-version }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
       with:
         java-version: ${{ inputs.java-version }}
         distribution: sapmachine
         cache: maven
 
     - name: Setup Maven ${{ inputs.maven-version }}
-      uses: stCarolas/setup-maven@v5
+      uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
       with:
         maven-version: ${{ inputs.maven-version }}
 

--- a/.github/workflows/main-build-and-deploy-oss.yml
+++ b/.github/workflows/main-build-and-deploy-oss.yml
@@ -88,7 +88,7 @@ jobs:
     #needs: update-version
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       #- name: Download artifact
       #  uses: actions/download-artifact@v8
       #  with:
@@ -106,7 +106,7 @@ jobs:
       #    sonarq-token: ${{ secrets.SONARQ_TOKEN }}
       #    github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload Changed Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: root-build
           include-hidden-files: true
@@ -121,7 +121,7 @@ jobs:
     needs: [build]
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: root-build
       - name: Deploy

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -17,7 +17,7 @@ jobs:
         java-version: [ 17, 21 ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Build
         uses: ./.github/actions/build
@@ -81,10 +81,10 @@ jobs:
     environment: Release-Snapshot
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Java ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: sapmachine
@@ -94,7 +94,7 @@ jobs:
           server-password: DEPLOYMENT_PASS
 
       - name: Set up Maven ${{ env.MAVEN_VERSION }}
-        uses: stCarolas/setup-maven@v5
+        uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
         with:
           maven-version: ${{ env.MAVEN_VERSION }}
 

--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Build
         uses: ./.github/actions/build

--- a/cds-feature-advanced-event-mesh/src/main/java/com/sap/cds/feature/messaging/aem/jms/AemMessagingConnectionProvider.java
+++ b/cds-feature-advanced-event-mesh/src/main/java/com/sap/cds/feature/messaging/aem/jms/AemMessagingConnectionProvider.java
@@ -173,23 +173,4 @@ public class AemMessagingConnectionProvider extends BrokerConnectionProvider {
       }
     }
   }
-
-      }
-      String mgmtHost = mgmt.getHost();
-      if (mgmtHost == null) {
-        throw new ServiceException(
-            "Management URI in binding '" + bindingName + "' has no host component.");
-      }
-      if (!amqpHost.equalsIgnoreCase(mgmtHost)) {
-        throw new ServiceException(
-            "AMQP URI host '"
-                + amqpHost
-                + "' does not match the management URI host '"
-                + mgmtHost
-                + "' in binding '"
-                + bindingName
-                + "'.");
-      }
-    }
-  }
 }

--- a/cds-feature-advanced-event-mesh/src/main/java/com/sap/cds/feature/messaging/aem/jms/AemMessagingConnectionProvider.java
+++ b/cds-feature-advanced-event-mesh/src/main/java/com/sap/cds/feature/messaging/aem/jms/AemMessagingConnectionProvider.java
@@ -138,16 +138,28 @@ public class AemMessagingConnectionProvider extends BrokerConnectionProvider {
               + parsed.getScheme()
               + "').");
     }
+    String amqpHost = parsed.getHost();
+    if (amqpHost == null) {
+      throw new ServiceException(
+          "AMQP URI in binding '" + bindingName + "' has no host component.");
+    }
     if (managementUri != null) {
       URI mgmt;
       try {
         mgmt = new URI(managementUri);
       } catch (URISyntaxException e) {
+        logger.warn(
+            "Skipping host-consistency check for binding '{}': management URI is malformed ({}).",
+            bindingName,
+            e.getMessage());
         return;
       }
-      String amqpHost = parsed.getHost();
       String mgmtHost = mgmt.getHost();
-      if (amqpHost != null && mgmtHost != null && !amqpHost.equalsIgnoreCase(mgmtHost)) {
+      if (mgmtHost == null) {
+        throw new ServiceException(
+            "Management URI in binding '" + bindingName + "' has no host component.");
+      }
+      if (!amqpHost.equalsIgnoreCase(mgmtHost)) {
         throw new ServiceException(
             "AMQP URI host '"
                 + amqpHost

--- a/cds-feature-advanced-event-mesh/src/main/java/com/sap/cds/feature/messaging/aem/jms/AemMessagingConnectionProvider.java
+++ b/cds-feature-advanced-event-mesh/src/main/java/com/sap/cds/feature/messaging/aem/jms/AemMessagingConnectionProvider.java
@@ -13,6 +13,7 @@ import com.sap.cloud.sdk.cloudplatform.connectivity.ServiceBindingDestinationLoa
 import com.sap.cloud.sdk.cloudplatform.connectivity.ServiceBindingDestinationOptions;
 import jakarta.jms.Connection;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -44,6 +45,7 @@ public class AemMessagingConnectionProvider extends BrokerConnectionProvider {
                 () ->
                     new ServiceException(
                         "AMQP URI key is missing in the service binding. Please check the service binding configuration."));
+    validateAmqpUri(amqpUri, endpointView.getUri().orElse(null), binding.getName().orElse("<unnamed>"));
     amqpUri = amqpUri + SASL_MECHANISM_URI_PARAMETER;
 
     ServiceBindingDestinationOptions options =
@@ -108,5 +110,43 @@ public class AemMessagingConnectionProvider extends BrokerConnectionProvider {
     }
 
     return token;
+  }
+
+  static void validateAmqpUri(String amqpUri, String managementUri, String bindingName) {
+    URI parsed;
+    try {
+      parsed = new URI(amqpUri);
+    } catch (URISyntaxException e) {
+      throw new ServiceException(
+          "Invalid AMQP URI in binding '" + bindingName + "': " + e.getMessage(), e);
+    }
+    if (parsed.getScheme() == null || !parsed.getScheme().equalsIgnoreCase("amqps")) {
+      throw new ServiceException(
+          "AMQP URI in binding '"
+              + bindingName
+              + "' must use scheme 'amqps' (got '"
+              + parsed.getScheme()
+              + "').");
+    }
+    if (managementUri != null) {
+      URI mgmt;
+      try {
+        mgmt = new URI(managementUri);
+      } catch (URISyntaxException e) {
+        return;
+      }
+      String amqpHost = parsed.getHost();
+      String mgmtHost = mgmt.getHost();
+      if (amqpHost != null && mgmtHost != null && !amqpHost.equalsIgnoreCase(mgmtHost)) {
+        throw new ServiceException(
+            "AMQP URI host '"
+                + amqpHost
+                + "' does not match the management URI host '"
+                + mgmtHost
+                + "' in binding '"
+                + bindingName
+                + "'.");
+      }
+    }
   }
 }

--- a/cds-feature-advanced-event-mesh/src/main/java/com/sap/cds/feature/messaging/aem/jms/AemMessagingConnectionProvider.java
+++ b/cds-feature-advanced-event-mesh/src/main/java/com/sap/cds/feature/messaging/aem/jms/AemMessagingConnectionProvider.java
@@ -152,7 +152,28 @@ public class AemMessagingConnectionProvider extends BrokerConnectionProvider {
             "Skipping host-consistency check for binding '{}': management URI is malformed ({}).",
             bindingName,
             e.getMessage());
-        return;
+        mgmt = null;
+      }
+      if (mgmt != null) {
+        String mgmtHost = mgmt.getHost();
+        if (mgmtHost == null) {
+          throw new ServiceException(
+              "Management URI in binding '" + bindingName + "' has no host component.");
+        }
+        if (!amqpHost.equalsIgnoreCase(mgmtHost)) {
+          throw new ServiceException(
+              "AMQP URI host '"
+                  + amqpHost
+                  + "' does not match the management URI host '"
+                  + mgmtHost
+                  + "' in binding '"
+                  + bindingName
+                  + "'.");
+        }
+      }
+    }
+  }
+
       }
       String mgmtHost = mgmt.getHost();
       if (mgmtHost == null) {

--- a/cds-feature-advanced-event-mesh/src/main/java/com/sap/cds/feature/messaging/aem/service/AemMessagingServiceConfiguration.java
+++ b/cds-feature-advanced-event-mesh/src/main/java/com/sap/cds/feature/messaging/aem/service/AemMessagingServiceConfiguration.java
@@ -17,7 +17,6 @@ import com.sap.cds.services.utils.environment.ServiceBindingUtils;
 import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -182,9 +181,9 @@ public class AemMessagingServiceConfiguration implements CdsRuntimeConfiguration
   static Optional<ServiceBinding> selectValidationBinding(List<ServiceBinding> validationBindings) {
     if (validationBindings.size() > 1) {
       String names =
-          validationBindings.stream()
-              .map(b -> b.getName().orElse("<unnamed>"))
-              .collect(Collectors.joining(", "));
+          String.join(
+              ", ",
+              validationBindings.stream().map(b -> b.getName().orElse("<unnamed>")).toList());
       throw new ServiceException(
           "Found "
               + validationBindings.size()

--- a/cds-feature-advanced-event-mesh/src/main/java/com/sap/cds/feature/messaging/aem/service/AemMessagingServiceConfiguration.java
+++ b/cds-feature-advanced-event-mesh/src/main/java/com/sap/cds/feature/messaging/aem/service/AemMessagingServiceConfiguration.java
@@ -17,6 +17,7 @@ import com.sap.cds.services.utils.environment.ServiceBindingUtils;
 import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,12 +48,13 @@ public class AemMessagingServiceConfiguration implements CdsRuntimeConfiguration
                         || binding.getTags().contains(BINDING_AEM_LABEL))
             .toList();
     Optional<ServiceBinding> validationBinding =
-        configurer
-            .getCdsRuntime()
-            .getEnvironment()
-            .getServiceBindings()
-            .filter(binding -> ServiceBindingUtils.matches(binding, BINDING_AEM_VALIDATION_LABEL))
-            .findFirst();
+        selectValidationBinding(
+            configurer
+                .getCdsRuntime()
+                .getEnvironment()
+                .getServiceBindings()
+                .filter(binding -> ServiceBindingUtils.matches(binding, BINDING_AEM_VALIDATION_LABEL))
+                .toList());
 
     if (bindings.isEmpty()) {
       logger.info("No service bindings with name '{}' found", BINDING_AEM_LABEL);
@@ -175,5 +177,23 @@ public class AemMessagingServiceConfiguration implements CdsRuntimeConfiguration
         binding.getName().get());
 
     return outboxed(service, serviceConfig, runtime);
+  }
+
+  static Optional<ServiceBinding> selectValidationBinding(List<ServiceBinding> validationBindings) {
+    if (validationBindings.size() > 1) {
+      String names =
+          validationBindings.stream()
+              .map(b -> b.getName().orElse("<unnamed>"))
+              .collect(Collectors.joining(", "));
+      throw new ServiceException(
+          "Found "
+              + validationBindings.size()
+              + " '"
+              + BINDING_AEM_VALIDATION_LABEL
+              + "' service bindings ("
+              + names
+              + "). Exactly one validation binding is supported per application.");
+    }
+    return validationBindings.isEmpty() ? Optional.empty() : Optional.of(validationBindings.get(0));
   }
 }

--- a/cds-feature-advanced-event-mesh/src/test/java/com/sap/cds/feature/messaging/aem/jms/AemMessagingConnectionProviderTest.java
+++ b/cds-feature-advanced-event-mesh/src/test/java/com/sap/cds/feature/messaging/aem/jms/AemMessagingConnectionProviderTest.java
@@ -1,0 +1,89 @@
+package com.sap.cds.feature.messaging.aem.jms;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sap.cds.services.ServiceException;
+import org.junit.jupiter.api.Test;
+
+public class AemMessagingConnectionProviderTest {
+
+  @Test
+  void validateAmqpUri_acceptsAmqpsWithMatchingHost() {
+    assertDoesNotThrow(
+        () ->
+            AemMessagingConnectionProvider.validateAmqpUri(
+                "amqps://broker.example.com:5671",
+                "https://broker.example.com:943",
+                "my-binding"));
+  }
+
+  @Test
+  void validateAmqpUri_acceptsAmqpsWhenManagementUriIsNull() {
+    assertDoesNotThrow(
+        () ->
+            AemMessagingConnectionProvider.validateAmqpUri(
+                "amqps://broker.example.com:5671", null, "my-binding"));
+  }
+
+  @Test
+  void validateAmqpUri_isCaseInsensitiveOnScheme() {
+    assertDoesNotThrow(
+        () ->
+            AemMessagingConnectionProvider.validateAmqpUri(
+                "AMQPS://broker.example.com:5671", null, "my-binding"));
+  }
+
+  @Test
+  void validateAmqpUri_rejectsPlainAmqp() {
+    ServiceException ex =
+        assertThrows(
+            ServiceException.class,
+            () ->
+                AemMessagingConnectionProvider.validateAmqpUri(
+                    "amqp://broker.example.com:5672", null, "my-binding"));
+    assertTrue(ex.getMessage().contains("amqps"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("my-binding"), ex.getMessage());
+  }
+
+  @Test
+  void validateAmqpUri_rejectsUnexpectedScheme() {
+    assertThrows(
+        ServiceException.class,
+        () ->
+            AemMessagingConnectionProvider.validateAmqpUri(
+                "ws://broker.example.com", null, "my-binding"));
+  }
+
+  @Test
+  void validateAmqpUri_rejectsMalformedUri() {
+    assertThrows(
+        ServiceException.class,
+        () ->
+            AemMessagingConnectionProvider.validateAmqpUri(
+                "::not a uri::", null, "my-binding"));
+  }
+
+  @Test
+  void validateAmqpUri_rejectsHostMismatchAgainstManagementUri() {
+    ServiceException ex =
+        assertThrows(
+            ServiceException.class,
+            () ->
+                AemMessagingConnectionProvider.validateAmqpUri(
+                    "amqps://attacker.example.com:5671",
+                    "https://broker.example.com:943",
+                    "my-binding"));
+    assertTrue(ex.getMessage().contains("attacker.example.com"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("broker.example.com"), ex.getMessage());
+  }
+
+  @Test
+  void validateAmqpUri_toleratesMalformedManagementUri() {
+    assertDoesNotThrow(
+        () ->
+            AemMessagingConnectionProvider.validateAmqpUri(
+                "amqps://broker.example.com:5671", "::not a uri::", "my-binding"));
+  }
+}

--- a/cds-feature-advanced-event-mesh/src/test/java/com/sap/cds/feature/messaging/aem/jms/AemMessagingConnectionProviderTest.java
+++ b/cds-feature-advanced-event-mesh/src/test/java/com/sap/cds/feature/messaging/aem/jms/AemMessagingConnectionProviderTest.java
@@ -170,4 +170,30 @@ class AemMessagingConnectionProviderTest {
             AemMessagingConnectionProvider.validateAmqpUri(
                 "amqps://broker.example.com:5671", "::not a uri::", "my-binding"));
   }
+
+  @Test
+  void validateAmqpUri_rejectsAmqpUriWithoutHost() {
+    // Opaque URI parses successfully but has no host component.
+    ServiceException ex =
+        assertThrows(
+            ServiceException.class,
+            () ->
+                AemMessagingConnectionProvider.validateAmqpUri(
+                    "amqps:opaque-body", null, "my-binding"));
+    assertTrue(ex.getMessage().contains("my-binding"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("host"), ex.getMessage());
+  }
+
+  @Test
+  void validateAmqpUri_rejectsManagementUriWithoutHost() {
+    // Management URI parses but yields a null host — must not silently pass the check.
+    ServiceException ex =
+        assertThrows(
+            ServiceException.class,
+            () ->
+                AemMessagingConnectionProvider.validateAmqpUri(
+                    "amqps://broker.example.com:5671", "https:opaque-body", "my-binding"));
+    assertTrue(ex.getMessage().contains("my-binding"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("host"), ex.getMessage());
+  }
 }

--- a/cds-feature-advanced-event-mesh/src/test/java/com/sap/cds/feature/messaging/aem/service/AemMessagingServiceConfigurationTest.java
+++ b/cds-feature-advanced-event-mesh/src/test/java/com/sap/cds/feature/messaging/aem/service/AemMessagingServiceConfigurationTest.java
@@ -3,15 +3,21 @@ package com.sap.cds.feature.messaging.aem.service;
 import static com.sap.cds.services.outbox.OutboxService.unboxed;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.sap.cds.services.Service;
+import com.sap.cds.services.ServiceException;
 import com.sap.cds.services.environment.CdsProperties;
 import com.sap.cds.services.environment.CdsProperties.Messaging.MessagingServiceConfig;
 import com.sap.cds.services.impl.environment.SimplePropertiesProvider;
 import com.sap.cds.services.outbox.OutboxService;
 import com.sap.cds.services.runtime.CdsRuntimeConfigurer;
+import com.sap.cloud.environment.servicebinding.api.DefaultServiceBinding;
+import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
@@ -224,5 +230,45 @@ public class AemMessagingServiceConfigurationTest {
         .toList();
 
     assertTrue(services.stream().findFirst().get().getSkipManagement());
+  }
+
+  @Test
+  void selectValidationBinding_returnsEmpty_whenNoneProvided() {
+    Optional<ServiceBinding> result =
+        AemMessagingServiceConfiguration.selectValidationBinding(List.of());
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void selectValidationBinding_returnsSingle_whenExactlyOneProvided() {
+    ServiceBinding only = validationBinding("primary");
+    Optional<ServiceBinding> result =
+        AemMessagingServiceConfiguration.selectValidationBinding(List.of(only));
+    assertTrue(result.isPresent());
+    assertEquals("primary", result.get().getName().orElseThrow());
+  }
+
+  @Test
+  void selectValidationBinding_throws_whenMultipleProvided() {
+    ServiceBinding first = validationBinding("primary");
+    ServiceBinding second = validationBinding("secondary");
+
+    ServiceException ex =
+        assertThrows(
+            ServiceException.class,
+            () -> AemMessagingServiceConfiguration.selectValidationBinding(List.of(first, second)));
+
+    assertTrue(ex.getMessage().contains("primary"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("secondary"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("aem-validation-service"), ex.getMessage());
+  }
+
+  private static ServiceBinding validationBinding(String name) {
+    return DefaultServiceBinding.builder()
+        .copy(Map.<String, Object>of())
+        .withName(name)
+        .withServiceName(AemMessagingServiceConfiguration.BINDING_AEM_VALIDATION_LABEL)
+        .withCredentials(Map.of())
+        .build();
   }
 }


### PR DESCRIPTION
Addresses security-compliance#18 findings 7, 8, and 10.

- **Finding 7** (AMQPS + broker consistency): `38745e7`, `7d77dd9`, `2aa6c2f`
- **Finding 8** (pin mutable GitHub Actions in deploy paths): `e01d80b`
- **Finding 10** (validation-binding fan-out): `0724149`

Remaining from that issue:
- #6 (secret rotation) — needs owner attestation that credentials are revoked
- #9 (host-only validation payload) — accepted risk; validation-service API contract requires hostName only