### PR TITLE
chore(deps): ignore cds-services-bom in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       # cds-services-bom major bumps require coordinated compat review; pin via manual PRs.
       - dependency-name: "com.sap.cds:cds-services-bom"
         update-types: ["version-update:semver-major"]
-
+  - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,8 @@ updates:
     ignore:
       # cds-services-bom major bumps require coordinated compat review; pin via manual PRs.
       - dependency-name: "com.sap.cds:cds-services-bom"
-  - package-ecosystem: github-actions
+        update-types: ["version-update:semver-major"]
+
     directory: "/"
     schedule:
       interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    ignore:
+      # cds-services-bom major bumps require coordinated compat review; pin via manual PRs.
+      - dependency-name: "com.sap.cds:cds-services-bom"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
Major bumps of `com.sap.cds:cds-services-bom` require coordinated compat review, so keep them out of the automated dependency PR stream and handle them manually.

Closes #220 (5.0.0 bump) — will be re-evaluated as a manual PR.